### PR TITLE
Fix modrinth api version not found

### DIFF
--- a/core/src/main/java/dev/phoenix616/updater/sources/ModrinthSource.java
+++ b/core/src/main/java/dev/phoenix616/updater/sources/ModrinthSource.java
@@ -49,7 +49,7 @@ public class ModrinthSource extends UpdateSource {
 
     private static final List<String> REQUIRED_PLACEHOLDERS = Arrays.asList("user");
     private static final String API_HEADER = "application/json";
-    private static final String VERSION_URL = "https://api.modrinth.com/v2/project/%project%/versions&featured=%featured%";
+    private static final String VERSION_URL = "https://api.modrinth.com/v2/project/%project%/version?featured=%featured%";
 
     public ModrinthSource(Updater updater) {
         super(updater, SourceType.MODRINTH, REQUIRED_PLACEHOLDERS);


### PR DESCRIPTION
When attempting to download using the Modrinth source, the program was unable to find the correct version due to an wrong api endpoint.

The error was returned `{"error":"not_found","description":"the requested route does not exist"}`